### PR TITLE
Export SyncType/FsEvent as values; never let onModuleDestroy throw

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flagsync/nestjs-sdk",
-  "version": "0.8.4",
+  "version": "0.8.5-alpha.0",
   "description": "FlagSync SDK for Nest.js",
   "author": "Mike Chabot",
   "license": "Apache-2.0",

--- a/src/flagsync-core.module.ts
+++ b/src/flagsync-core.module.ts
@@ -92,10 +92,23 @@ export class FlagSyncCoreModule implements OnModuleDestroy {
     };
   }
 
+  /**
+   * Defensive on purpose: builds of 0.8.3 shipped without constructor param
+   * decoration (esbuild drops emitDecoratorMetadata), leaving moduleRef
+   * undefined and making this hook throw — which aborts the rest of Nest's
+   * shutdown chain and leaks the SDK's connections. Never let a missing
+   * client break app.close().
+   */
   async onModuleDestroy() {
-    const client = this.moduleRef.get<FsClient>(FLAGSYNC_CLIENT);
-    if (client) {
-      await client.destroy();
+    try {
+      const client = this.moduleRef?.get<FsClient>(FLAGSYNC_CLIENT);
+      if (client) {
+        await client.destroy();
+      }
+    } catch (e) {
+      new Logger(FlagSyncCoreModule.name).warn(
+        `Failed to destroy FlagSync client on shutdown: ${e}`,
+      );
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,16 @@ export type {
   LogLevel,
   FsUserContext,
   FeatureFlags,
-  FsEvent,
-  SyncType,
   NoExplicitReturnType,
   IsFeatureFlagsEmpty,
   FlagReturnType,
 } from '@flagsync/node-sdk';
+
+/**
+ * Runtime values, not types — a type-only re-export compiles fine but leaves
+ * them undefined at runtime (e.g. `SyncType.Sse` throwing at module init).
+ */
+export { FsEvent, SyncType } from '@flagsync/node-sdk';
 
 export { InjectFlagSync } from './decorators';
 export { type FlagSyncModuleAsyncOptions } from './types';


### PR DESCRIPTION
SyncType and FsEvent are runtime const objects in @flagsync/node-sdk, but were re-exported here with `export type`, so the .d.ts declared them while the compiled output left them undefined — `SyncType.Sse` threw at module init, forcing users to write string literals instead.

Also harden onModuleDestroy: published 0.8.3 shipped without constructor param decoration (esbuild drops emitDecoratorMetadata; fixed by the explicit @Inject in c1309e8), which made this hook throw on app.close() and abort the rest of Nest's shutdown chain, leaking the SDK's connections. Destroy failures are now caught and logged so shutdown always completes.


Claude-Session: https://claude.ai/code/session_01XHpkNV7Bi4SHg4cjon8HqP